### PR TITLE
Change interpreter for test_video_resource.py

### DIFF
--- a/scripts/test_video_resource.py
+++ b/scripts/test_video_resource.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
 


### PR DESCRIPTION
Change interpreter for test_video_resource.py to python2 for systems which use Python 3 as default.
