### PR TITLE
Add option to set resolution of video stream.

### DIFF
--- a/launch/camera.launch
+++ b/launch/camera.launch
@@ -16,6 +16,9 @@
   	<arg name="flip_vertical" default="false" />
   	<!-- if show a image_view window subscribed to the generated stream -->
 	<arg name="visualize" default="false"/>
+	<arg name="width" default="640"/>
+	<arg name="height" default="480"/>
+
    
    	<!-- images will be published at /camera_name/image with the image transports plugins (e.g.: compressed) installed -->
    	<group ns="$(arg camera_name)">
@@ -28,6 +31,8 @@
 	        <param name="camera_info_url" type="string" value="$(arg camera_info_url)" />
 	        <param name="flip_horizontal" type="bool" value="$(arg flip_horizontal)" />
 	        <param name="flip_vertical" type="bool" value="$(arg flip_vertical)" />
+	        <param name="width" type="int" value="$(arg width)" />
+	        <param name="height" type="int" value="$(arg height)" />
 	    </node>
 
 	    <node if="$(arg visualize)" name="$(arg camera_name)_image_view" pkg="image_view" type="image_view">

--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -109,6 +109,11 @@ int main(int argc, char** argv)
     _nh.param("flip_vertical", flip_vertical, false);
     ROS_INFO_STREAM("Flip flip_vertical image is : " << ((flip_vertical)?"true":"false"));
 
+    int width_target;
+    int height_target;
+    _nh.param("width", width_target, 640);
+    _nh.param("height", height_target, 480);
+
     // From http://docs.opencv.org/modules/core/doc/operations_on_arrays.html#void flip(InputArray src, OutputArray dst, int flipCode)
     // FLIP_HORIZONTAL == 1, FLIP_VERTICAL == 0 or FLIP_BOTH == -1
     bool flip_image = true;
@@ -126,6 +131,8 @@ int main(int argc, char** argv)
         ROS_ERROR_STREAM("Could not open the stream.");
         return -1;
     }
+    cap.set(CV_CAP_PROP_FRAME_WIDTH, width_target);
+    cap.set(CV_CAP_PROP_FRAME_HEIGHT, height_target);
 
     ROS_INFO_STREAM("Opened the stream, starting to publish.");
 


### PR DESCRIPTION
Add an option to set the resolution of the video stream using the CV_CAP_PROP_FRAME parameters. I needed this to be able to use the full angle of view of a camera with an aspect ratio of 16:9.

Thought this would be useful to have.