### PR TITLE
Fix empty frame id in camera info header

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -244,6 +244,7 @@ int main(int argc, char** argv)
     camera_info_manager::CameraInfoManager cam_info_manager(nh, camera_name, camera_info_url);
     // Get the saved camera info if any
     cam_info_msg = cam_info_manager.getCameraInfo();
+    cam_info_msg.header = header;
     
     ROS_INFO_STREAM("Opened the stream, starting to publish.");
     boost::thread cap_thread(do_capture, nh);


### PR DESCRIPTION
The camera info messages published from the video_stream node do not have the 'header/frame_id' field populated (they are set to ''). 

In my case this is preventing me from using the RViz camera view, as I believe it requires the frame_id to be set in the camera_info message.

Having a look at the camera info manager, I found the following warning associated with CameraInfoManager::getCameraInfo(void)
`
 @warning The caller @em must fill in the message Header of the  CameraInfo returned.  The time stamp and frame_id should normally be the same as the corresponding Image message Header fields.
`
https://github.com/ros-perception/image_common/blob/hydro-devel/camera_info_manager/src/camera_info_manager.cpp#L101

It looks like the video stream node fails to do this when *not* using the default camera info.

The provided fix rectifies this by adding the same header that is used for the image message to the camera info message as well.

