### PR TITLE
Fixing ever growing memory when using boost::sync_queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(video_stream_opencv)
+add_definitions(
+    -std=c++11
+)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -86,8 +86,6 @@ sensor_msgs::CameraInfo get_default_camera_info_from_image(sensor_msgs::ImagePtr
 
 void do_capture(ros::NodeHandle &nh) {
     cv::Mat frame;
-    cv::Mat _drop_frame;
-
     ros::Rate camera_fps_rate(set_camera_fps);
 
     // Read frames as fast as possible
@@ -98,18 +96,16 @@ void do_capture(ros::NodeHandle &nh) {
             camera_fps_rate.sleep();
         }
 
-        {
+        if(!frame.empty()) {
             std::lock_guard<std::mutex> g(q_mutex);
-            if(!frame.empty()) {
-                // accumulate only until max_queue_size
-                if (framesQueue.size() < max_queue_size) {
-                    framesQueue.push(frame);
-                }
-                // once reached, drop the oldest frame
-                else {
-                    framesQueue.pop();
-                    framesQueue.push(frame);
-                }
+            // accumulate only until max_queue_size
+            if (framesQueue.size() < max_queue_size) {
+                framesQueue.push(frame);
+            }
+            // once reached, drop the oldest frame
+            else {
+                framesQueue.pop();
+                framesQueue.push(frame);
             }
         }
     }

--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -44,9 +44,11 @@
 #include <fstream>
 #include <boost/assign/list_of.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/thread/sync_queue.hpp>
+#include <queue>
+#include <mutex>
 
-boost::sync_queue<cv::Mat> framesQueue;
+std::mutex q_mutex;
+std::queue<cv::Mat> framesQueue;
 cv::VideoCapture cap;
 std::string video_stream_provider_type;
 double set_camera_fps;
@@ -68,16 +70,16 @@ sensor_msgs::CameraInfo get_default_camera_info_from_image(sensor_msgs::ImagePtr
     cam_info_msg.D.resize(5, 0.0);
     // Give a reasonable default intrinsic camera matrix
     cam_info_msg.K = boost::assign::list_of(1.0) (0.0) (img->width/2.0)
-                                           (0.0) (1.0) (img->height/2.0)
-                                           (0.0) (0.0) (1.0);
+            (0.0) (1.0) (img->height/2.0)
+            (0.0) (0.0) (1.0);
     // Give a reasonable default rectification matrix
     cam_info_msg.R = boost::assign::list_of (1.0) (0.0) (0.0)
-                                            (0.0) (1.0) (0.0)
-                                            (0.0) (0.0) (1.0);
+            (0.0) (1.0) (0.0)
+            (0.0) (0.0) (1.0);
     // Give a reasonable default projection matrix
     cam_info_msg.P = boost::assign::list_of (1.0) (0.0) (img->width/2.0) (0.0)
-                                            (0.0) (1.0) (img->height/2.0) (0.0)
-                                            (0.0) (0.0) (1.0) (0.0);
+            (0.0) (1.0) (img->height/2.0) (0.0)
+            (0.0) (0.0) (1.0) (0.0);
     return cam_info_msg;
 }
 
@@ -91,19 +93,23 @@ void do_capture(ros::NodeHandle &nh) {
     // Read frames as fast as possible
     while (nh.ok()) {
         cap >> frame;
-	if (video_stream_provider_type == "videofile")
-	{
-         camera_fps_rate.sleep();
-	}
-        if(!frame.empty()) {
-            // accumulate only until max_queue_size
-            if (framesQueue.size() < max_queue_size) {
-                framesQueue.push(frame.clone());
-            }
-            // once reached, drop the oldest frame
-            else {
-                framesQueue.pull(_drop_frame);
-                framesQueue.push(frame.clone());
+        if (video_stream_provider_type == "videofile")
+        {
+            camera_fps_rate.sleep();
+        }
+
+        {
+            std::lock_guard<std::mutex> g(q_mutex);
+            if(!frame.empty()) {
+                // accumulate only until max_queue_size
+                if (framesQueue.size() < max_queue_size) {
+                    framesQueue.push(frame);
+                }
+                // once reached, drop the oldest frame
+                else {
+                    framesQueue.pop();
+                    framesQueue.push(frame);
+                }
             }
         }
     }
@@ -131,8 +137,8 @@ int main(int argc, char** argv)
         }
         else{
             ROS_INFO_STREAM("Getting video from provider: " << video_stream_provider);
-            if (video_stream_provider.find("http://") != std::string::npos || 
-                video_stream_provider.find("https://") != std::string::npos){
+            if (video_stream_provider.find("http://") != std::string::npos ||
+                    video_stream_provider.find("https://") != std::string::npos){
                 video_stream_provider_type = "http_stream";
             }
             else if(video_stream_provider.find("rtsp://") != std::string::npos){
@@ -161,11 +167,11 @@ int main(int argc, char** argv)
     std::string camera_name;
     _nh.param("camera_name", camera_name, std::string("camera"));
     ROS_INFO_STREAM("Camera name: " << camera_name);
-    
+
     _nh.param("set_camera_fps", set_camera_fps, 30.0);
     ROS_INFO_STREAM("Setting camera FPS to: " << set_camera_fps);
     cap.set(CV_CAP_PROP_FPS, set_camera_fps);
-    
+
     double reported_camera_fps;
     // OpenCV 2.4 returns -1 (instead of a 0 as the spec says) and prompts an error
     // HIGHGUI ERROR: V4L2: Unable to get property <unknown property string>(5) - Invalid argument
@@ -174,7 +180,7 @@ int main(int argc, char** argv)
         ROS_INFO_STREAM("Camera reports FPS: " << reported_camera_fps);
     else
         ROS_INFO_STREAM("Backend can't provide camera FPS information");
-    
+
     int buffer_queue_size;
     _nh.param("buffer_queue_size", buffer_queue_size, 100);
     ROS_INFO_STREAM("Setting buffer size for capturing frames to: " << buffer_queue_size);
@@ -183,11 +189,11 @@ int main(int argc, char** argv)
     double fps;
     _nh.param("fps", fps, 240.0);
     ROS_INFO_STREAM("Throttling to fps: " << fps);
-    
+
     if (video_stream_provider.size() < 4 && fps > set_camera_fps)
         ROS_WARN_STREAM("Asked to publish at 'fps' (" << fps
-        << ") which is higher than the 'set_camera_fps' (" << set_camera_fps <<
-        "), we can't publish faster than the camera provides images.");
+                        << ") which is higher than the 'set_camera_fps' (" << set_camera_fps <<
+                        "), we can't publish faster than the camera provides images.");
 
     std::string frame_id;
     _nh.param("frame_id", frame_id, std::string("camera"));
@@ -245,14 +251,20 @@ int main(int argc, char** argv)
     // Get the saved camera info if any
     cam_info_msg = cam_info_manager.getCameraInfo();
     cam_info_msg.header = header;
-    
+
     ROS_INFO_STREAM("Opened the stream, starting to publish.");
     boost::thread cap_thread(do_capture, nh);
 
     ros::Rate r(fps);
     while (nh.ok()) {
-	if (!framesQueue.empty())
-		framesQueue.pull(frame);
+
+        {
+            std::lock_guard<std::mutex> g(q_mutex);
+            if (!framesQueue.empty()){
+                frame = framesQueue.front();
+                framesQueue.pop();
+            }
+        }
 
         if (pub.getNumSubscribers() > 0){
             // Check if grabbed frame is actually filled with some content


### PR DESCRIPTION
The code does exacly the same thing, except that locks are done once per consum/produce cycle. It fixes as well a possible edge case where the user sets a queue size of 1 and 2 calls of pull can happen on after the other from the 2 different threads, leading the second pull to return either the previous picture (consumer pulls last) or an empty image (producer pulls last).

The growing memory comes from the boost implementation at least using the upstream Ubuntu 16.04 version of Boost (1.58.0.1).