### PR TITLE
Convert video_stream node to nodelet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   camera_info_manager
   sensor_msgs
+  nodelet
 )
 
 
@@ -23,10 +24,14 @@ include_directories(
   ${OpenCV_INCLUDE_DIRS}
 )
 
-add_executable(video_stream src/video_stream.cpp)
-target_link_libraries(video_stream ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+add_library(${PROJECT_NAME} SHARED src/video_stream.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
-install(TARGETS video_stream
+add_executable(video_stream_node src/video_stream_node.cpp)
+target_link_libraries(video_stream_node ${catkin_LIBRARIES})
+set_target_properties(video_stream_node PROPERTIES OUTPUT_NAME video_stream)
+
+install(TARGETS video_stream_node
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(PROGRAMS
@@ -36,6 +41,9 @@ install(PROGRAMS
 )
 
 install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(FILES nodelet_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,10 @@
+<library path="lib/libvideo_stream_opencv">
+  <class name="video_stream_opencv/VideoStream"
+         type="video_stream_opencv::VideoStreamNodelet"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      A nodelet to publish a video stream
+      (the protocols that opencv supports are supported, including rtsp, webcams on /dev/video and video files)
+    </description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>camera_info_manager</build_depend>
+  <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -29,6 +30,7 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>camera_info_manager</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -36,4 +38,7 @@
   <test_depend>rostest</test_depend>
   <test_depend>rostopic</test_depend>
 
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
+  </export>
 </package>

--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -35,6 +35,7 @@
  */
 
 #include <ros/ros.h>
+#include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>
 #include <camera_info_manager/camera_info_manager.h>
 #include <opencv2/highgui/highgui.hpp>
@@ -47,25 +48,43 @@
 #include <queue>
 #include <mutex>
 
+
+namespace video_stream_opencv {
+
+class VideoStreamNodelet: public nodelet::Nodelet {
+protected:
+boost::shared_ptr<ros::NodeHandle> nh, pnh;
+image_transport::CameraPublisher pub;
 std::mutex q_mutex;
 std::queue<cv::Mat> framesQueue;
-cv::VideoCapture cap;
+cv::Mat frame;
+boost::shared_ptr<cv::VideoCapture> cap;
 std::string video_stream_provider;
 std::string video_stream_provider_type;
+std::string frame_id;
 double set_camera_fps;
+double fps;
 int max_queue_size;
 bool loop_videofile;
+bool is_subscribed;
+int width_target;
+int height_target;
+bool flip_image;
+int flip_value;
+boost::thread capture_thread;
+ros::Timer publish_timer;
+sensor_msgs::CameraInfo cam_info_msg;
 
 // Based on the ros tutorial on transforming opencv images to Image messages
 
-sensor_msgs::CameraInfo get_default_camera_info_from_image(sensor_msgs::ImagePtr img){
+virtual sensor_msgs::CameraInfo get_default_camera_info_from_image(sensor_msgs::ImagePtr img){
     sensor_msgs::CameraInfo cam_info_msg;
     cam_info_msg.header.frame_id = img->header.frame_id;
     // Fill image size
     cam_info_msg.height = img->height;
     cam_info_msg.width = img->width;
-    ROS_INFO_STREAM("The image width is: " << img->width);
-    ROS_INFO_STREAM("The image height is: " << img->height);
+    NODELET_INFO_STREAM("The image width is: " << img->width);
+    NODELET_INFO_STREAM("The image height is: " << img->height);
     // Add the most common distortion model as sensor_msgs/CameraInfo says
     cam_info_msg.distortion_model = "plumb_bob";
     // Don't let distorsion matrix be empty
@@ -86,16 +105,18 @@ sensor_msgs::CameraInfo get_default_camera_info_from_image(sensor_msgs::ImagePtr
 }
 
 
-void do_capture(ros::NodeHandle &nh) {
+virtual void do_capture() {
+    NODELET_DEBUG("Capture thread started");
     cv::Mat frame;
     ros::Rate camera_fps_rate(set_camera_fps);
 
     int frame_counter = 0;
     // Read frames as fast as possible
-    while (nh.ok()) {
-        if (!cap.read(frame))
+    while (nh->ok() && is_subscribed) {
+        if (!cap->read(frame))
         {
-            throw std::runtime_error("Could not capture frame!");
+          NODELET_FATAL("Could not capture frame!");
+          continue;
         }
 
         frame_counter++;
@@ -104,17 +125,16 @@ void do_capture(ros::NodeHandle &nh) {
             camera_fps_rate.sleep();
         }
         if (video_stream_provider_type == "videofile" &&
-            frame_counter == cap.get(CV_CAP_PROP_FRAME_COUNT)) 
+            frame_counter == cap->get(CV_CAP_PROP_FRAME_COUNT)) 
         {
             if (loop_videofile)
             {
-                cap.open(video_stream_provider);
+                cap->open(video_stream_provider);
                 frame_counter = 0;
             }
             else {
-                // Exit gently if we are done
-                nh.shutdown();
-                exit(EXIT_SUCCESS);
+              NODELET_INFO("Reached the end of frames");
+              break;
             }
         }
 
@@ -131,29 +151,139 @@ void do_capture(ros::NodeHandle &nh) {
             }
         }
     }
+    NODELET_DEBUG("Capture thread finished");
+}
+
+virtual void do_publish(const ros::TimerEvent& event) {
+    bool is_new_image = false;
+    sensor_msgs::ImagePtr msg;
+    std_msgs::Header header;
+    header.frame_id = frame_id;
+    {
+        std::lock_guard<std::mutex> g(q_mutex);
+        if (!framesQueue.empty()){
+            frame = framesQueue.front();
+            framesQueue.pop();
+            is_new_image = true;
+        }
+    }
+
+    // Check if grabbed frame is actually filled with some content
+    if(!frame.empty()) {
+        // Flip the image if necessary
+        if (flip_image && is_new_image)
+            cv::flip(frame, frame, flip_value);
+        msg = cv_bridge::CvImage(header, "bgr8", frame).toImageMsg();
+        // Create a default camera info if we didn't get a stored one on initialization
+        if (cam_info_msg.distortion_model == ""){
+            NODELET_WARN_STREAM("No calibration file given, publishing a reasonable default camera info.");
+            cam_info_msg = get_default_camera_info_from_image(msg);
+            // cam_info_manager.setCameraInfo(cam_info_msg);
+        }
+        // The timestamps are in sync thanks to this publisher
+        pub.publish(*msg, cam_info_msg, ros::Time::now());
+    }
+}
+
+virtual void subscribe() {
+  ROS_DEBUG("Subscribe");
+  cap.reset(new cv::VideoCapture);
+  if (video_stream_provider_type == "videodevice") {
+    NODELET_INFO_STREAM("Opening VideoCapture with provider: /dev/video" << video_stream_provider);
+    cap->open(std::stoi(video_stream_provider));
+  } else {
+    NODELET_INFO_STREAM("Opening VideoCapture with provider: " << video_stream_provider);
+    cap->open(video_stream_provider);
+  }
+
+  double reported_camera_fps;
+  // OpenCV 2.4 returns -1 (instead of a 0 as the spec says) and prompts an error
+  // HIGHGUI ERROR: V4L2: Unable to get property <unknown property string>(5) - Invalid argument
+  reported_camera_fps = cap->get(CV_CAP_PROP_FPS);
+  if (reported_camera_fps > 0.0)
+    NODELET_INFO_STREAM("Camera reports FPS: " << reported_camera_fps);
+  else
+    NODELET_INFO_STREAM("Backend can't provide camera FPS information");
+
+  cap->set(CV_CAP_PROP_FPS, set_camera_fps);
+  if(!cap->isOpened()){
+    NODELET_ERROR_STREAM("Could not open the stream.");
+    return;
+  }
+  if (width_target != 0 && height_target != 0){
+    cap->set(CV_CAP_PROP_FRAME_WIDTH, width_target);
+    cap->set(CV_CAP_PROP_FRAME_HEIGHT, height_target);
+  }
+  is_subscribed = true;
+  try {
+    capture_thread = boost::thread(
+      boost::bind(&VideoStreamNodelet::do_capture, this));
+    publish_timer = nh->createTimer(
+      ros::Duration(1.0 / fps), &VideoStreamNodelet::do_publish, this);
+  } catch (std::exception& e) {
+    NODELET_ERROR_STREAM(e.what());
+    is_subscribed = false;
+  }
+}
+
+virtual void unsubscribe() {
+  ROS_DEBUG("Unsubscribe");
+  publish_timer.stop();
+  is_subscribed = false;
+  capture_thread.join();
+  cap.reset();
+}
+
+virtual void connectionCallbackImpl() {
+  bool always_subscribe = false;
+  pnh->getParamCached("always_subscribe", always_subscribe);
+  if ((video_stream_provider == "videofile" || always_subscribe) && !is_subscribed) {
+    subscribe();
+  } else {
+    if (pub.getNumSubscribers() > 0) {
+    if (!is_subscribed) subscribe();
+    } else {
+      if (is_subscribed) unsubscribe();
+    }
+  }
+}
+
+virtual void connectionCallback(const image_transport::SingleSubscriberPublisher&) {
+  connectionCallbackImpl();
+}
+
+virtual void infoConnectionCallback(const ros::SingleSubscriberPublisher&) {
+  connectionCallbackImpl();
 }
 
 
-int main(int argc, char** argv)
-{
-    ros::init(argc, argv, "image_publisher");
-    ros::NodeHandle nh;
-    ros::NodeHandle _nh("~"); // to get the private params
-    image_transport::ImageTransport it(nh);
-    image_transport::CameraPublisher pub = it.advertiseCamera("camera", 1);
+virtual void onInit() {
+    bool use_multithread;
+    ros::param::param<bool>("~use_multithread_callback", use_multithread, true);
+    if (use_multithread)
+    {
+      NODELET_DEBUG("Using multithread callback");
+      nh.reset (new ros::NodeHandle(getMTNodeHandle()));
+      pnh.reset (new ros::NodeHandle(getMTPrivateNodeHandle()));
+    }
+    else
+    {
+      NODELET_DEBUG("Using singlethread callback");
+      nh.reset(new ros::NodeHandle(getNodeHandle()));
+      pnh.reset(new ros::NodeHandle(getPrivateNodeHandle()));
+    }
 
     // provider can be an url (e.g.: rtsp://10.0.0.1:554) or a number of device, (e.g.: 0 would be /dev/video0)
-    if (_nh.getParam("video_stream_provider", video_stream_provider)){
-        ROS_INFO_STREAM("Resource video_stream_provider: " << video_stream_provider);
+    if (pnh->getParam("video_stream_provider", video_stream_provider)){
+        NODELET_INFO_STREAM("Resource video_stream_provider: " << video_stream_provider);
         // If we are given a string of 4 chars or less (I don't think we'll have more than 100 video devices connected)
         // treat is as a number and act accordingly so we open up the videoNUMBER device
         if (video_stream_provider.size() < 4){
-            ROS_INFO_STREAM("Getting video from provider: /dev/video" << video_stream_provider);
+            NODELET_INFO_STREAM("Getting video from provider: /dev/video" << video_stream_provider);
             video_stream_provider_type = "videodevice";
-            cap.open(atoi(video_stream_provider.c_str()));
         }
         else{
-            ROS_INFO_STREAM("Getting video from provider: " << video_stream_provider);
+            NODELET_INFO_STREAM("Getting video from provider: " << video_stream_provider);
             if (video_stream_provider.find("http://") != std::string::npos ||
                     video_stream_provider.find("https://") != std::string::npos){
                 video_stream_provider_type = "http_stream";
@@ -171,76 +301,60 @@ int main(int argc, char** argv)
                 else
                     video_stream_provider_type = "unknown";
             }
-            cap.open(video_stream_provider);
         }
     }
     else{
-        ROS_ERROR("Failed to get param 'video_stream_provider'");
-        return -1;
+        NODELET_ERROR("Failed to get param 'video_stream_provider'");
+        return;
     }
 
-    ROS_INFO_STREAM("Video stream provider type detected: " << video_stream_provider_type);
+    NODELET_INFO_STREAM("Video stream provider type detected: " << video_stream_provider_type);
 
     std::string camera_name;
-    _nh.param("camera_name", camera_name, std::string("camera"));
-    ROS_INFO_STREAM("Camera name: " << camera_name);
+    pnh->param("camera_name", camera_name, std::string("camera"));
+    NODELET_INFO_STREAM("Camera name: " << camera_name);
 
-    _nh.param("set_camera_fps", set_camera_fps, 30.0);
-    ROS_INFO_STREAM("Setting camera FPS to: " << set_camera_fps);
-    cap.set(CV_CAP_PROP_FPS, set_camera_fps);
-
-    double reported_camera_fps;
-    // OpenCV 2.4 returns -1 (instead of a 0 as the spec says) and prompts an error
-    // HIGHGUI ERROR: V4L2: Unable to get property <unknown property string>(5) - Invalid argument
-    reported_camera_fps = cap.get(CV_CAP_PROP_FPS);
-    if (reported_camera_fps > 0.0)
-        ROS_INFO_STREAM("Camera reports FPS: " << reported_camera_fps);
-    else
-        ROS_INFO_STREAM("Backend can't provide camera FPS information");
+    pnh->param("set_camera_fps", set_camera_fps, 30.0);
+    NODELET_INFO_STREAM("Setting camera FPS to: " << set_camera_fps);
 
     int buffer_queue_size;
-    _nh.param("buffer_queue_size", buffer_queue_size, 100);
-    ROS_INFO_STREAM("Setting buffer size for capturing frames to: " << buffer_queue_size);
+    pnh->param("buffer_queue_size", buffer_queue_size, 100);
+    NODELET_INFO_STREAM("Setting buffer size for capturing frames to: " << buffer_queue_size);
     max_queue_size = buffer_queue_size;
 
-    double fps;
-    _nh.param("fps", fps, 240.0);
-    ROS_INFO_STREAM("Throttling to fps: " << fps);
+    pnh->param("fps", fps, 240.0);
+    NODELET_INFO_STREAM("Throttling to fps: " << fps);
 
     if (video_stream_provider.size() < 4 && fps > set_camera_fps)
-        ROS_WARN_STREAM("Asked to publish at 'fps' (" << fps
+        NODELET_WARN_STREAM("Asked to publish at 'fps' (" << fps
                         << ") which is higher than the 'set_camera_fps' (" << set_camera_fps <<
                         "), we can't publish faster than the camera provides images.");
 
-    std::string frame_id;
-    _nh.param("frame_id", frame_id, std::string("camera"));
-    ROS_INFO_STREAM("Publishing with frame_id: " << frame_id);
+    pnh->param("frame_id", frame_id, std::string("camera"));
+    NODELET_INFO_STREAM("Publishing with frame_id: " << frame_id);
 
     std::string camera_info_url;
-    _nh.param("camera_info_url", camera_info_url, std::string(""));
-    ROS_INFO_STREAM("Provided camera_info_url: '" << camera_info_url << "'");
+    pnh->param("camera_info_url", camera_info_url, std::string(""));
+    NODELET_INFO_STREAM("Provided camera_info_url: '" << camera_info_url << "'");
 
     bool flip_horizontal;
-    _nh.param("flip_horizontal", flip_horizontal, false);
-    ROS_INFO_STREAM("Flip horizontal image is: " << ((flip_horizontal)?"true":"false"));
+    pnh->param("flip_horizontal", flip_horizontal, false);
+    NODELET_INFO_STREAM("Flip horizontal image is: " << ((flip_horizontal)?"true":"false"));
 
     bool flip_vertical;
-    _nh.param("flip_vertical", flip_vertical, false);
-    ROS_INFO_STREAM("Flip vertical image is: " << ((flip_vertical)?"true":"false"));
+    pnh->param("flip_vertical", flip_vertical, false);
+    NODELET_INFO_STREAM("Flip vertical image is: " << ((flip_vertical)?"true":"false"));
 
-    int width_target;
-    int height_target;
-    _nh.param("width", width_target, 0);
-    _nh.param("height", height_target, 0);
+    pnh->param("width", width_target, 0);
+    pnh->param("height", height_target, 0);
     if (width_target != 0 && height_target != 0){
-        ROS_INFO_STREAM("Forced image width is: " << width_target);
-        ROS_INFO_STREAM("Forced image height is: " << height_target);
+        NODELET_INFO_STREAM("Forced image width is: " << width_target);
+        NODELET_INFO_STREAM("Forced image height is: " << height_target);
     }
 
     // From http://docs.opencv.org/modules/core/doc/operations_on_arrays.html#void flip(InputArray src, OutputArray dst, int flipCode)
     // FLIP_HORIZONTAL == 1, FLIP_VERTICAL == 0 or FLIP_BOTH == -1
-    bool flip_image = true;
-    int flip_value;
+    flip_image = true;
     if (flip_horizontal && flip_vertical)
         flip_value = -1; // flip both, horizontal and vertical
     else if (flip_horizontal)
@@ -250,63 +364,27 @@ int main(int argc, char** argv)
     else
         flip_image = false;
 
-    _nh.param("loop_videofile", loop_videofile, false);
+    pnh->param("loop_videofile", loop_videofile, false);
 
-    if(!cap.isOpened()){
-        ROS_ERROR_STREAM("Could not open the stream.");
-        return -1;
-    }
-    if (width_target != 0 && height_target != 0){
-        cap.set(CV_CAP_PROP_FRAME_WIDTH, width_target);
-        cap.set(CV_CAP_PROP_FRAME_HEIGHT, height_target);
-    }
-
-    cv::Mat frame;
-    sensor_msgs::ImagePtr msg;
-    sensor_msgs::CameraInfo cam_info_msg;
     std_msgs::Header header;
     header.frame_id = frame_id;
-    camera_info_manager::CameraInfoManager cam_info_manager(nh, camera_name, camera_info_url);
+    camera_info_manager::CameraInfoManager cam_info_manager(*nh, camera_name, camera_info_url);
     // Get the saved camera info if any
     cam_info_msg = cam_info_manager.getCameraInfo();
     cam_info_msg.header = header;
 
-    ROS_INFO_STREAM("Opened the stream, starting to publish.");
-    boost::thread cap_thread(do_capture, nh);
-
-    ros::Rate r(fps);
-    bool is_new_image = true;
-    while (nh.ok()) {
-
-        {
-            std::lock_guard<std::mutex> g(q_mutex);
-            if (!framesQueue.empty()){
-                frame = framesQueue.front();
-                framesQueue.pop();
-                is_new_image = true;
-            }
-        }
-
-        if (pub.getNumSubscribers() > 0){
-            // Check if grabbed frame is actually filled with some content
-            if(!frame.empty()) {
-                // Flip the image if necessary
-                if (flip_image && is_new_image)
-                    cv::flip(frame, frame, flip_value);
-                msg = cv_bridge::CvImage(header, "bgr8", frame).toImageMsg();
-                // Create a default camera info if we didn't get a stored one on initialization
-                if (cam_info_msg.distortion_model == ""){
-                    ROS_WARN_STREAM("No calibration file given, publishing a reasonable default camera info.");
-                    cam_info_msg = get_default_camera_info_from_image(msg);
-                    cam_info_manager.setCameraInfo(cam_info_msg);
-                }
-                // The timestamps are in sync thanks to this publisher
-                pub.publish(*msg, cam_info_msg, ros::Time::now());
-            }
-            is_new_image = false;
-            ros::spinOnce();
-        }
-        r.sleep();
-    }
-    cap_thread.join();
+    image_transport::SubscriberStatusCallback connect_cb =
+      boost::bind(&VideoStreamNodelet::connectionCallback, this, _1);
+    ros::SubscriberStatusCallback info_connect_cb =
+      boost::bind(&VideoStreamNodelet::infoConnectionCallback, this, _1);
+    pub = image_transport::ImageTransport(*nh).advertiseCamera(
+      "image_raw", 1,
+      connect_cb, connect_cb,
+      info_connect_cb, info_connect_cb,
+      ros::VoidPtr(), false);
 }
+};
+} // namespace
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(video_stream_opencv::VideoStreamNodelet, nodelet::Nodelet)

--- a/src/video_stream_node.cpp
+++ b/src/video_stream_node.cpp
@@ -1,0 +1,18 @@
+#include <ros/ros.h>
+#include <nodelet/loader.h>
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "video_stream");
+
+    nodelet::Loader manager(true);
+    nodelet::M_string remappings;
+    nodelet::V_string my_argv(argv + 1, argv + argc);
+    my_argv.push_back("--shutdown-on-close"); // Internal
+
+    manager.load(ros::this_node::getName(), "video_stream_opencv/VideoStream", remappings, my_argv);
+
+    ros::spin();
+
+    return 0;
+}


### PR DESCRIPTION
This PR changes `video_stream` node to nodelet and adds a new node to treat as a standalone nodelet with the same name.
By using `video_stream` nodelet, we can use captured image without serialization/deserialization, which results in faster / less-memory processing.