### PR TITLE
Fix dependency of file generated by dynamic_reconfigure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} SHARED src/video_stream.cpp)
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 add_executable(video_stream_node src/video_stream_node.cpp)


### PR DESCRIPTION
* video_stream.cpp uses a header file generated by dynamic_reconfigure and
  it should depend on video_stream_opencv_gencfg.