### PR TITLE
add option to re-open camera device on read failure

### DIFF
--- a/cfg/VideoStream.cfg
+++ b/cfg/VideoStream.cfg
@@ -24,5 +24,6 @@ gen.add("saturation", double_t, 0, "Target saturation", 0.64, 0.0, 1.0)
 gen.add("auto_exposure", bool_t, 0, "Target auto exposure", True)
 gen.add("exposure", double_t, 0, "Target exposure", 0.5, 0.0, 1.0)
 gen.add("loop_videofile", bool_t, 0, "Loop videofile", False)
+gen.add("reopen_on_read_failure", bool_t, 0, "Re-open camera device on read failure", False)
 
 exit(gen.generate(PKG, PKG, "VideoStream"))


### PR DESCRIPTION
In some cases, camera capture thread stucks on read failure on my environment when capturing images from camera devices.
In this pull request, I added the option for dynamic reconfigure: `reopen_on_read_failure` for enabling/disabling the feature to reopen the camera device when the `read` method of `cv::VideoCapture` class fails, by which it restarts publishing without restarting entire node on my environment.