### PR TITLE
libvideo_stream_opencv depends on gencfg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,10 @@ include_directories(
 
 add_library(${PROJECT_NAME} SHARED src/video_stream.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 add_executable(video_stream_node src/video_stream_node.cpp)
 target_link_libraries(video_stream_node ${catkin_LIBRARIES})
-add_dependencies(video_stream_node ${PROJECT_NAME}_gencfg)
 set_target_properties(video_stream_node PROPERTIES OUTPUT_NAME video_stream)
 
 install(TARGETS video_stream_node


### PR DESCRIPTION
Currently target of `gencfg` is depended by only video_stream_node, and not by a library.
This PR is to add dependencies of gencfg to library.

```
src/video_stream.cpp:52:10: fatal error: video_stream_opencv/VideoStreamConfig.h: No such file or directory
 #include <video_stream_opencv/VideoStreamConfig.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/video_stream_opencv.dir/src/video_stream.cpp.o] Error 1
make[1]: *** [CMakeFiles/video_stream_opencv.dir/all] Error 2
make: *** [all] Error 2
```