### PR TITLE
Allow setting of pixel format (bgr8 and rgb8 are supported)

### DIFF
--- a/cfg/VideoStream.cfg
+++ b/cfg/VideoStream.cfg
@@ -25,5 +25,6 @@ gen.add("auto_exposure", bool_t, 0, "Target auto exposure", True)
 gen.add("exposure", double_t, 0, "Target exposure", 0.5, 0.0, 1.0)
 gen.add("loop_videofile", bool_t, 0, "Loop videofile", False)
 gen.add("reopen_on_read_failure", bool_t, 0, "Re-open camera device on read failure", False)
+gen.add("output_pixel_encoding", str_t, 0, "Output Pixel Encoding format", "bgr8")
 
 exit(gen.generate(PKG, PKG, "VideoStream"))

--- a/launch/camera.launch
+++ b/launch/camera.launch
@@ -25,12 +25,14 @@
     <!-- enable looping playback, only if video_stream_provider is a video file -->
     <arg name="loop_videofile" default="false" />
   	<!-- if show a image_view window subscribed to the generated stream -->
-	<arg name="visualize" default="false"/>
+	  <arg name="visualize" default="false"/>
+    <!-- output pixel encoding format, defaults to bgr8 -->
+	  <arg name="output_pixel_encoding" default="bgr8"/>
 
-   
+
    	<!-- images will be published at /camera_name/image with the image transports plugins (e.g.: compressed) installed -->
    	<group ns="$(arg camera_name)">
-	    <node pkg="video_stream_opencv" type="video_stream" name="$(arg camera_name)_stream" output="screen"> 
+	    <node pkg="video_stream_opencv" type="video_stream" name="$(arg camera_name)_stream" output="screen">
 	    	<remap from="camera" to="image_raw" />
 	    	<param name="camera_name" type="string" value="$(arg camera_name)" />
 	        <param name="video_stream_provider" type="string" value="$(arg video_stream_provider)" />
@@ -44,7 +46,8 @@
           <param name="loop_videofile" type="bool" value="$(arg loop_videofile)" />
 	        <param name="width" type="int" value="$(arg width)" />
 	        <param name="height" type="int" value="$(arg height)" />
-	    </node>
+          <param name="output_pixel_encoding" type="string" value="$(arg output_pixel_encoding)" />
+ 	    </node>
 
 	    <node if="$(arg visualize)" name="$(arg camera_name)_image_view" pkg="image_view" type="image_view">
 	    	<remap from="image" to="image_raw" />


### PR DESCRIPTION
Partial Fix for #46. Support bgr8 and rgb8 formats. The format can be selecting using the "output_pixel_encoding" parameter. The capture node will convert from BGR to RGB format before enqueuing the frame.

