### PR TITLE
use variable config instead of class properties

### DIFF
--- a/cfg/VideoStream.cfg
+++ b/cfg/VideoStream.cfg
@@ -6,24 +6,30 @@ PKG = "video_stream_opencv"
 
 gen = ParameterGenerator()
 
+
+class LEVEL:
+    NORMAL = 0
+    RUNNING = 1
+
+
 #       name    type     level     description     default      min      max
-gen.add("camera_name", str_t, 0, "Camera name", "camera")
-gen.add("set_camera_fps", double_t, 0, "Image Publish Rate", 30.0, 0.0, 1000.0)
-gen.add("buffer_queue_size", int_t, 0, "Buffer size for capturing frames", 100, 1, 1000)
-gen.add("fps", double_t, 0, "Image Publish Rate", 240.0, 0.0, 1000.0)
-gen.add("frame_id", str_t, 0, "Camera FrameID", "camera")
-gen.add("camera_info_url", str_t, 0, "Camera info URL", "")
-gen.add("flip_horizontal", bool_t, 0, "Flip image horizontally", False)
-gen.add("flip_vertical", bool_t, 0, "Flip image vertically", False)
-gen.add("width", int_t, 0, "Target width", 0, 0, 10000)
-gen.add("height", int_t, 0, "Target height", 0, 0, 10000)
-gen.add("brightness", double_t, 0, "Target brightness", 0.5019607843137255, 0.0, 1.0)
-gen.add("contrast", double_t, 0, "Target contrast", 0.12549019607843137, 0.0, 1.0)
-gen.add("hue", double_t, 0, "Target hue", 0.5, 0.0, 1.0)
-gen.add("saturation", double_t, 0, "Target saturation", 0.64, 0.0, 1.0)
-gen.add("auto_exposure", bool_t, 0, "Target auto exposure", True)
-gen.add("exposure", double_t, 0, "Target exposure", 0.5, 0.0, 1.0)
-gen.add("loop_videofile", bool_t, 0, "Loop videofile", False)
-gen.add("reopen_on_read_failure", bool_t, 0, "Re-open camera device on read failure", False)
+gen.add("camera_name", str_t, LEVEL.NORMAL, "Camera name", "camera")
+gen.add("set_camera_fps", double_t, LEVEL.RUNNING, "Image Publish Rate", 30.0, 0.0, 1000.0)
+gen.add("buffer_queue_size", int_t, LEVEL.NORMAL, "Buffer size for capturing frames", 100, 1, 1000)
+gen.add("fps", double_t, LEVEL.RUNNING, "Image Publish Rate", 240.0, 0.0, 1000.0)
+gen.add("frame_id", str_t, LEVEL.RUNNING, "Camera FrameID", "camera")
+gen.add("camera_info_url", str_t, LEVEL.RUNNING, "Camera info URL", "")
+gen.add("flip_horizontal", bool_t, LEVEL.NORMAL, "Flip image horizontally", False)
+gen.add("flip_vertical", bool_t, LEVEL.NORMAL, "Flip image vertically", False)
+gen.add("width", int_t, LEVEL.RUNNING, "Target width", 0, 0, 10000)
+gen.add("height", int_t, LEVEL.RUNNING, "Target height", 0, 0, 10000)
+gen.add("brightness", double_t, LEVEL.RUNNING, "Target brightness", 0.5019607843137255, 0.0, 1.0)
+gen.add("contrast", double_t, LEVEL.RUNNING, "Target contrast", 0.12549019607843137, 0.0, 1.0)
+gen.add("hue", double_t, LEVEL.RUNNING, "Target hue", 0.5, 0.0, 1.0)
+gen.add("saturation", double_t, LEVEL.RUNNING, "Target saturation", 0.64, 0.0, 1.0)
+gen.add("auto_exposure", bool_t, LEVEL.RUNNING, "Target auto exposure", True)
+gen.add("exposure", double_t, LEVEL.RUNNING, "Target exposure", 0.5, 0.0, 1.0)
+gen.add("loop_videofile", bool_t, LEVEL.RUNNING, "Loop videofile", False)
+gen.add("reopen_on_read_failure", bool_t, LEVEL.RUNNING, "Re-open camera device on read failure", False)
 
 exit(gen.generate(PKG, PKG, "VideoStream"))


### PR DESCRIPTION
In the original code, setting configuration directly to VideoCapture object in the callback function of dynamic_reconfigure, where setting parameters may fail if the object is not initialized or opened.
(e.g. https://github.com/ros-drivers/video_stream_opencv/blob/master/src/video_stream.cpp#L364 )
This PR changes to let the callback function just update internal variables of the parameters and the subscribe function set all the parameters instead.
The internal variables are also replaced with VideoStreamConfig object to make tracking the change of the parameters easier.