### PR TITLE
Add option to set output_encoding

### DIFF
--- a/cfg/VideoStream.cfg
+++ b/cfg/VideoStream.cfg
@@ -31,5 +31,6 @@ gen.add("auto_exposure", bool_t, LEVEL.RUNNING, "Target auto exposure", True)
 gen.add("exposure", double_t, LEVEL.RUNNING, "Target exposure", 0.5, 0.0, 1.0)
 gen.add("loop_videofile", bool_t, LEVEL.RUNNING, "Loop videofile", False)
 gen.add("reopen_on_read_failure", bool_t, LEVEL.RUNNING, "Re-open camera device on read failure", False)
+gen.add("output_encoding", str_t, LEVEL.NORMAL, "Output encoding", "bgr8")
 
 exit(gen.generate(PKG, PKG, "VideoStream"))

--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -201,6 +201,7 @@ virtual void do_publish(const ros::TimerEvent& event) {
         if (latest_config.output_encoding != "bgr8")
         {
           try {
+            // https://github.com/ros-perception/vision_opencv/blob/melodic/cv_bridge/include/cv_bridge/cv_bridge.h#L247
             cv_image = cv_bridge::cvtColor(cv_image, latest_config.output_encoding);
           } catch (std::runtime_error &ex) {
             NODELET_ERROR_STREAM("cannot change encoding to " << latest_config.output_encoding


### PR DESCRIPTION
This PR overrides
https://github.com/ros-drivers/video_stream_opencv/pull/47
to support all available output encoding.