### PR TITLE
get canonical file for target device

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -413,7 +413,7 @@ virtual void onInit() {
         video_stream_provider_type = "rtsp_stream";
       }
       else{
-        fs::file_type file_type = fs::status(fs::path(video_stream_provider)).type();
+        fs::file_type file_type = fs::status(fs::canonical(fs::path(video_stream_provider))).type();
         switch (file_type) {
         case fs::file_type::character_file:
         case fs::file_type::block_file:


### PR DESCRIPTION
#59 was being caused because a symlink to the dev/videoX location does not get red properly as a character or block type file. The solution is to get the canonical path (no symlinks, no `..`) before testing the file. 

On some newer versions of boost, this seems to not be a problem? But getting the canonical path would seem to always be a good thing. 