### PR TITLE
Subscribe function changes config globally

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -222,7 +222,7 @@ virtual void do_publish(const ros::TimerEvent& event) {
 
 virtual void subscribe() {
   ROS_DEBUG("Subscribe");
-  VideoStreamConfig latest_config = config;
+  VideoStreamConfig latest_config& = config;
   // initialize camera info publisher
   camera_info_manager::CameraInfoManager cam_info_manager(
       *nh, latest_config.camera_name, latest_config.camera_info_url);


### PR DESCRIPTION
Take out the latest_config-variable as a reference instead of a copy. Ensuring that the code which changes the stop_frame variable is changed globally. Fixes "Could not capture frame" error produced when the number of frames exceeds the maximum number of frames in a video file. 

Issue https://github.com/ros-drivers/video_stream_opencv/issues/61#issue-594011639