### PR TITLE
Noticed the default camera info was actually wrong, corrected

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -88,16 +88,16 @@ virtual sensor_msgs::CameraInfo get_default_camera_info_from_image(sensor_msgs::
     // Don't let distorsion matrix be empty
     cam_info_msg.D.resize(5, 0.0);
     // Give a reasonable default intrinsic camera matrix
-    cam_info_msg.K = boost::assign::list_of(1.0) (0.0) (img->width/2.0)
-            (0.0) (1.0) (img->height/2.0)
+    cam_info_msg.K = boost::assign::list_of(img->width/2.0) (0.0) (img->width/2.0)
+            (0.0) (img->height/2.0) (img->height/2.0)
             (0.0) (0.0) (1.0);
     // Give a reasonable default rectification matrix
     cam_info_msg.R = boost::assign::list_of (1.0) (0.0) (0.0)
             (0.0) (1.0) (0.0)
             (0.0) (0.0) (1.0);
     // Give a reasonable default projection matrix
-    cam_info_msg.P = boost::assign::list_of (1.0) (0.0) (img->width/2.0) (0.0)
-            (0.0) (1.0) (img->height/2.0) (0.0)
+    cam_info_msg.P = boost::assign::list_of (img->width/2.0) (0.0) (img->width/2.0) (0.0)
+            (0.0) (img->height/2.0) (img->height/2.0) (0.0)
             (0.0) (0.0) (1.0) (0.0);
     return cam_info_msg;
 }


### PR DESCRIPTION
The documentation of the CameraInfo message states what should be in it. Given it's just a default, I guess no one really uses it, but I wanted to try the [jsk CameraInfo plugin for rviz](https://jsk-visualization.readthedocs.io/en/latest/jsk_rviz_plugins/plugins/camera_info.html) and being wrong it didn't work.

The documentation states this:
```
# Intrinsic camera matrix for the raw (distorted) images.
#     [fx  0 cx]
# K = [ 0 fy cy]
#     [ 0  0  1]
# Projects 3D points in the camera coordinate frame to 2D pixel
# coordinates using the focal lengths (fx, fy) and principal point
# (cx, cy).
float64[9]  K # 3x3 row-major matrix

# Rectification matrix (stereo cameras only)
# A rotation matrix aligning the camera coordinate system to the ideal
# stereo image plane so that epipolar lines in both stereo images are
# parallel.
float64[9]  R # 3x3 row-major matrix

# Projection/camera matrix
#     [fx'  0  cx' Tx]
# P = [ 0  fy' cy' Ty]
#     [ 0   0   1   0]
# By convention, this matrix specifies the intrinsic (camera) matrix
#  of the processed (rectified) image. That is, the left 3x3 portion
#  is the normal camera intrinsic matrix for the rectified image.
# It projects 3D points in the camera coordinate frame to 2D pixel
#  coordinates using the focal lengths (fx', fy') and principal point
#  (cx', cy') - these may differ from the values in K.
# For monocular cameras, Tx = Ty = 0. Normally, monocular cameras will
#  also have R = the identity and P[1:3,1:3] = K.
# For a stereo pair, the fourth column [Tx Ty 0]' is related to the
#  position of the optical center of the second camera in the first
#  camera's frame. We assume Tz = 0 so both cameras are in the same
#  stereo image plane. The first camera always has Tx = Ty = 0. For
#  the right (second) camera of a horizontal stereo pair, Ty = 0 and
#  Tx = -fx' * B, where B is the baseline between the cameras.
# Given a 3D point [X Y Z]', the projection (x, y) of the point onto
#  the rectified image is given by:
#  [u v w]' = P * [X Y Z 1]'
#         x = u / w
#         y = v / w
#  This holds for both images of a stereo pair.
float64[12] P # 3x4 row-major matrix
```
And we were setting '1.0' instead of fx, fy (image width/height divided by 2.0).

Proof now it works correctly:
![Screenshot from 2020-10-09 20-15-28](https://user-images.githubusercontent.com/1721716/95565758-5abccb00-0a6c-11eb-8301-5e65fe535509.png)

