### PR TITLE
Fix subscribe/unsubscribe behavior

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -122,13 +122,18 @@ virtual void do_capture() {
           cv::waitKey(100);
           continue;
         }
-        if (!cap->read(capture_frame)) {
-          NODELET_ERROR_STREAM_THROTTLE(1.0, "Could not capture frame (frame_counter: " << frame_counter << ")");
-          if (latest_config.reopen_on_read_failure) {
-            NODELET_WARN_STREAM_THROTTLE(1.0, "trying to reopen the device");
-            unsubscribe();
-            subscribe();
+        try {
+          if (!cap->read(capture_frame)) {
+            NODELET_ERROR_STREAM_THROTTLE(1.0, "Could not capture frame (frame_counter: " << frame_counter << ")");
+            if (latest_config.reopen_on_read_failure) {
+              NODELET_WARN_STREAM_THROTTLE(1.0, "trying to reopen the device");
+              unsubscribe();
+              subscribe();
+            }
           }
+        } catch (const cv::Exception &e) {
+            NODELET_WARN("Error reading frame");
+            continue;
         }
 
         frame_counter++;

--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -373,22 +373,6 @@ virtual void disconnectionCallbackImpl() {
   }
 }
 
-virtual void connectionCallback(const image_transport::SingleSubscriberPublisher&) {
-  connectionCallbackImpl();
-}
-
-virtual void infoConnectionCallback(const ros::SingleSubscriberPublisher&) {
-  connectionCallbackImpl();
-}
-
-virtual void disconnectionCallback(const image_transport::SingleSubscriberPublisher&) {
-  disconnectionCallbackImpl();
-}
-
-virtual void infoDisconnectionCallback(const ros::SingleSubscriberPublisher&) {
-  disconnectionCallbackImpl();
-}
-
 virtual void configCallback(VideoStreamConfig& new_config, uint32_t level) {
   NODELET_DEBUG("configCallback");
 
@@ -477,13 +461,13 @@ virtual void onInit() {
     dyn_srv->setCallback(f);
 
     image_transport::SubscriberStatusCallback connect_cb =
-      boost::bind(&VideoStreamNodelet::connectionCallback, this, _1);
+      boost::bind(&VideoStreamNodelet::connectionCallbackImpl, this);
     ros::SubscriberStatusCallback info_connect_cb =
-      boost::bind(&VideoStreamNodelet::infoConnectionCallback, this, _1);
+      boost::bind(&VideoStreamNodelet::connectionCallbackImpl, this);
     image_transport::SubscriberStatusCallback disconnect_cb =
-      boost::bind(&VideoStreamNodelet::disconnectionCallback, this, _1);
+      boost::bind(&VideoStreamNodelet::disconnectionCallbackImpl, this);
     ros::SubscriberStatusCallback info_disconnect_cb =
-      boost::bind(&VideoStreamNodelet::infoDisconnectionCallback, this, _1);
+      boost::bind(&VideoStreamNodelet::disconnectionCallbackImpl, this);
     pub = image_transport::ImageTransport(*nh).advertiseCamera(
       "image_raw", 1,
       connect_cb, disconnect_cb,


### PR DESCRIPTION
This PR fixes the subscribe/unsubscribe behavior of the node, especially when the camera errors out or is disconnected.

In our setup we enable `ar_track_alvar` on demand (subscribes/unsubscribes), this enables hot-plugging of the camera devices and better error recovery.