### PR TITLE
fix: remove log message bomb

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -124,6 +124,8 @@ virtual void do_capture() {
         }
         if (!cap->read(frame)) {
           NODELET_ERROR_STREAM("Could not capture frame (frame_counter: " << frame_counter << ")");
+          // Don't message bomb /rosout and ros logs
+          camera_fps_rate.sleep();
           if (latest_config.reopen_on_read_failure) {
             NODELET_WARN("trying to reopen the device");
             unsubscribe();


### PR DESCRIPTION
Removes message bomb that happens if a frame fails to capture for whatever reason.
It was generating 1.5 Gb/sec on the rosbag and equally as much in the ~/.ros/log folder.