### PR TITLE
Fix test for distros after ubuntu 18.04

### DIFF
--- a/test/mjpg_server.py
+++ b/test/mjpg_server.py
@@ -9,7 +9,10 @@ import os
 import rospy
 import sys
 import time
-from BaseHTTPServer import BaseHTTPRequestHandler
+if sys.version_info[0] < 3:
+    from BaseHTTPServer import BaseHTTPRequestHandler
+else:
+    from http.server import BaseHTTPRequestHandler
 from BaseHTTPServer import HTTPServer
 from SocketServer import ThreadingMixIn
 


### PR DESCRIPTION
Fixes the buildfarm error:
```
12:18:34 Traceback (most recent call last):
12:18:34   File "/tmp/ws/src/video_stream_opencv/test/mjpg_server.py", line 12, in <module>
12:18:34     from BaseHTTPServer import BaseHTTPRequestHandler
12:18:34 ModuleNotFoundError: No module named 'BaseHTTPServer'
```