### PR TITLE
Allow buffer_queue_size = 0

### DIFF
--- a/cfg/VideoStream.cfg
+++ b/cfg/VideoStream.cfg
@@ -15,7 +15,7 @@ class LEVEL:
 #       name    type     level     description     default      min      max
 gen.add("camera_name", str_t, LEVEL.NORMAL, "Camera name", "camera")
 gen.add("set_camera_fps", double_t, LEVEL.RUNNING, "Image Publish Rate", 30.0, 0.0, 1000.0)
-gen.add("buffer_queue_size", int_t, LEVEL.NORMAL, "Buffer size for capturing frames", 100, 1, 1000)
+gen.add("buffer_queue_size", int_t, LEVEL.NORMAL, "Buffer size for capturing frames", 100, 0, 1000)
 gen.add("fps", double_t, LEVEL.RUNNING, "Image Publish Rate", 240.0, 0.0, 1000.0)
 gen.add("frame_id", str_t, LEVEL.RUNNING, "Camera FrameID", "camera")
 gen.add("camera_info_url", str_t, LEVEL.RUNNING, "Camera info URL", "")


### PR DESCRIPTION
We should allow buffer_queue_size = 0 to add an option to publish only the latest image.
According to https://github.com/ros-drivers/video_stream_opencv/blob/68cde068bed55488a9d452ee12a9158838843589/src/video_stream.cpp#L159 it will still work
The frame will be kept in the queue even with queue size = 0 because pop is before the push instruction.