### PR TITLE
When setting queue_size to 1, we actually had 2 images in the buffer,…

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -156,7 +156,7 @@ virtual void do_capture() {
         if(!frame.empty()) {
             std::lock_guard<std::mutex> g(q_mutex);
             // accumulate only until max_queue_size
-            while (framesQueue.size() > latest_config.buffer_queue_size) {
+            while (framesQueue.size() >= latest_config.buffer_queue_size) {
               framesQueue.pop();
             }
             framesQueue.push(frame.clone());


### PR DESCRIPTION
… so we could be delayed by 1 frame.

Reimplements: https://github.com/ros-drivers/video_stream_opencv/pull/93

By doing what we actually were trying to do.