### PR TITLE
normalize properties to fix issues after upgrading OpenCV

### DIFF
--- a/src/video_stream.cpp
+++ b/src/video_stream.cpp
@@ -288,6 +288,7 @@ virtual void subscribe() {
     cap->set(cv::CAP_PROP_FRAME_HEIGHT, latest_config.height);
   }
 
+  cap->set(cv::CAP_PROP_MODE, true); // normalize property ranges
   cap->set(cv::CAP_PROP_BRIGHTNESS, latest_config.brightness);
   cap->set(cv::CAP_PROP_CONTRAST, latest_config.contrast);
   cap->set(cv::CAP_PROP_HUE, latest_config.hue);


### PR DESCRIPTION
OpenCV 4 (e.g. in Ubuntu bionic with ROS noetic) disables the normalize-properties feature in the V4L2 driver per default. This patch re-enables to old behavior.

See also https://github.com/ros-drivers/video_stream_opencv/issues/92