### PR TITLE
Fix/missing image view

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,6 +37,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>image_view</run_depend>
+  <run_depend>roslaunch</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>rostopic</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>image_view</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>rostopic</test_depend>


### PR DESCRIPTION
**- Overview:**
  - This package defines a [launch](https://github.com/ros-drivers/video_stream_opencv/blob/65949bdc5c9468d18c51aed9073d020bec892532/launch/camera.launch#L54) that does use (as a runtime dependency) the`image view` pkg, but it is missing its definition in this package manifest.
   - I'm also adding a definition for `roslaunch` since this package offers some launch files.